### PR TITLE
Fix privacy policy horizontal overflow on mobile

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -28,8 +28,11 @@ img {
   pointer-events: none;
 }
 
+html,
 body {
+  max-width: 100%;
   overflow-x: hidden !important;
+  overscroll-behavior-x: none;
 }
 
 .login-button {

--- a/src/App.scss
+++ b/src/App.scss
@@ -28,8 +28,8 @@ img {
   pointer-events: none;
 }
 
-html,
-body {
+html.miniapp-privacy-policy,
+html.miniapp-privacy-policy body {
   max-width: 100%;
   overflow-x: hidden !important;
   overscroll-behavior-x: none;

--- a/src/App.scss
+++ b/src/App.scss
@@ -28,11 +28,8 @@ img {
   pointer-events: none;
 }
 
-html.miniapp-privacy-policy,
-html.miniapp-privacy-policy body {
-  max-width: 100%;
+body {
   overflow-x: hidden !important;
-  overscroll-behavior-x: none;
 }
 
 .login-button {

--- a/src/Components/LanguageSwitcher.tsx
+++ b/src/Components/LanguageSwitcher.tsx
@@ -19,10 +19,12 @@ export enum Languages {
 
 interface LanguageSwitcherProps {
     onLanguageChange: (lng: Languages) => void;
+    placement?: "bottom" | "bottom-end";
 }
 
 const LanguageSwitcher = ({
-    onLanguageChange
+    onLanguageChange,
+    placement
 }: LanguageSwitcherProps) => {
   const [language, setLanguage] = useState<Languages>(Languages.EN);
 
@@ -39,7 +41,7 @@ const LanguageSwitcher = ({
       right={isMobile ? "5px" : "45px"}
       top={isMobile ? "5px" : "40px"}
     >
-      <Menu placement="bottom-end">
+      <Menu placement={placement}>
         <MenuButton as={Button} p={"0 !important"} width={"auto"}>
           <Flex width={"25px"} m={"0 auto"}>
             <CircleFlagLanguage languageCode={language} />

--- a/src/Components/LanguageSwitcher.tsx
+++ b/src/Components/LanguageSwitcher.tsx
@@ -20,13 +20,16 @@ export enum Languages {
 interface LanguageSwitcherProps {
     onLanguageChange: (lng: Languages) => void;
     placement?: "bottom" | "bottom-end";
+    unmountMenuWhenClosed?: boolean;
 }
 
 const LanguageSwitcher = ({
     onLanguageChange,
-    placement
+    placement,
+    unmountMenuWhenClosed = false
 }: LanguageSwitcherProps) => {
   const [language, setLanguage] = useState<Languages>(Languages.EN);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const changeLanguage = (lng: Languages) => {
     setLanguage(lng);
@@ -41,32 +44,40 @@ const LanguageSwitcher = ({
       right={isMobile ? "5px" : "45px"}
       top={isMobile ? "5px" : "40px"}
     >
-      <Menu placement={placement}>
+      <Menu
+        onClose={
+          unmountMenuWhenClosed ? () => setIsMenuOpen(false) : undefined
+        }
+        onOpen={unmountMenuWhenClosed ? () => setIsMenuOpen(true) : undefined}
+        placement={placement}
+      >
         <MenuButton as={Button} p={"0 !important"} width={"auto"}>
           <Flex width={"25px"} m={"0 auto"}>
             <CircleFlagLanguage languageCode={language} />
           </Flex>
         </MenuButton>
-        <MenuList>
-          <MenuItem onClick={() => changeLanguage(Languages.EN)} gap={2}>
-            <Box width={"30px"}>
-              <CircleFlagLanguage languageCode="en-us" />
-            </Box>
-            English
-          </MenuItem>
-          <MenuItem onClick={() => changeLanguage(Languages.ES)} gap={2}>
-            <Box width={"30px"}>
-              <CircleFlagLanguage languageCode="es" />
-            </Box>
-            Español
-          </MenuItem>
-          <MenuItem onClick={() => changeLanguage(Languages.PT)} gap={2}>
-            <Box width={"30px"}>
-              <CircleFlagLanguage languageCode="pt" />
-            </Box>
-            Português
-          </MenuItem>
-        </MenuList>
+        {(!unmountMenuWhenClosed || isMenuOpen) && (
+          <MenuList>
+            <MenuItem onClick={() => changeLanguage(Languages.EN)} gap={2}>
+              <Box width={"30px"}>
+                <CircleFlagLanguage languageCode="en-us" />
+              </Box>
+              English
+            </MenuItem>
+            <MenuItem onClick={() => changeLanguage(Languages.ES)} gap={2}>
+              <Box width={"30px"}>
+                <CircleFlagLanguage languageCode="es" />
+              </Box>
+              Español
+            </MenuItem>
+            <MenuItem onClick={() => changeLanguage(Languages.PT)} gap={2}>
+              <Box width={"30px"}>
+                <CircleFlagLanguage languageCode="pt" />
+              </Box>
+              Português
+            </MenuItem>
+          </MenuList>
+        )}
       </Menu>
     </Box>
   );

--- a/src/Components/LanguageSwitcher.tsx
+++ b/src/Components/LanguageSwitcher.tsx
@@ -39,7 +39,7 @@ const LanguageSwitcher = ({
       right={isMobile ? "5px" : "45px"}
       top={isMobile ? "5px" : "40px"}
     >
-      <Menu>
+      <Menu placement="bottom-end">
         <MenuButton as={Button} p={"0 !important"} width={"auto"}>
           <Flex width={"25px"} m={"0 auto"}>
             <CircleFlagLanguage languageCode={language} />

--- a/src/theme/PrivacyPolicy.tsx
+++ b/src/theme/PrivacyPolicy.tsx
@@ -1,5 +1,5 @@
 import { Box, Heading, Link, Stack, Text } from "@chakra-ui/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import LanguageSwitcher, { Languages } from "../Components/LanguageSwitcher";
 
 /** ================= EN ================= **/
@@ -505,10 +505,26 @@ const getPrivacyByLanguage = (lang: Languages) => {
 
 export const PrivacyPolicy = () => {
   const [language, setLanguage] = useState<Languages>(Languages.EN);
+  const isMiniappEmbed =
+    window.self !== window.top &&
+    new URLSearchParams(window.location.search).get("embed") === "miniapp";
+
+  useEffect(() => {
+    if (!isMiniappEmbed) return;
+
+    document.documentElement.classList.add("miniapp-privacy-policy");
+
+    return () => {
+      document.documentElement.classList.remove("miniapp-privacy-policy");
+    };
+  }, [isMiniappEmbed]);
 
   return (
     <Box maxW="800px" mx="auto" px={4} py={8}>
-      <LanguageSwitcher onLanguageChange={(l) => setLanguage(l)} />
+      <LanguageSwitcher
+        onLanguageChange={(l) => setLanguage(l)}
+        placement={isMiniappEmbed ? "bottom-end" : undefined}
+      />
       {getPrivacyByLanguage(language)}
     </Box>
   );

--- a/src/theme/PrivacyPolicy.tsx
+++ b/src/theme/PrivacyPolicy.tsx
@@ -1,5 +1,5 @@
 import { Box, Heading, Link, Stack, Text } from "@chakra-ui/react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import LanguageSwitcher, { Languages } from "../Components/LanguageSwitcher";
 
 /** ================= EN ================= **/
@@ -509,21 +509,12 @@ export const PrivacyPolicy = () => {
     window.self !== window.top &&
     new URLSearchParams(window.location.search).get("embed") === "miniapp";
 
-  useEffect(() => {
-    if (!isMiniappEmbed) return;
-
-    document.documentElement.classList.add("miniapp-privacy-policy");
-
-    return () => {
-      document.documentElement.classList.remove("miniapp-privacy-policy");
-    };
-  }, [isMiniappEmbed]);
-
   return (
     <Box maxW="800px" mx="auto" px={4} py={8}>
       <LanguageSwitcher
         onLanguageChange={(l) => setLanguage(l)}
         placement={isMiniappEmbed ? "bottom-end" : undefined}
+        unmountMenuWhenClosed={isMiniappEmbed}
       />
       {getPrivacyByLanguage(language)}
     </Box>


### PR DESCRIPTION
## Summary

- Remove the actual source of mobile horizontal overflow: Chakra's hidden language menu remained mounted 139 px beyond the iframe viewport while closed.
- Unmount the language menu while closed only for the miniapp Privacy Policy embed.
- Place the menu at `bottom-end` while open so it stays inside the iframe.
- Restore `App.scss` exactly to its original state; this PR adds no global CSS changes.

Miniapp caller: https://github.com/caravana-studio/jokers-of-neon-app/pull/1449

## End-to-end validation

Tested through the complete miniapp route at a 390 × 844 mobile viewport with a 358 px iframe:

- Production reproduced: `scrollWidth: 497`, `clientWidth: 358`.
- Fixed, menu closed: menu is not mounted and `scrollWidth === clientWidth === 358`.
- Fixed, menu open: right edge is 313 px inside the 358 px iframe; document width remains 358 px.
- Horizontal navigation remains at `scrollLeft: 0`.
- Vertical navigation reaches `scrollY: 636` while the miniapp parent remains at `scrollY: 0`.
- Normal `/privacy-policy` keeps its original menu and CSS behavior.
- `npm run build` passes.

## Note

`npm run lint` currently fails across the repository because the existing ESLint parser/configuration cannot parse the TypeScript files; this patch does not add new lint failures.